### PR TITLE
Fix lingering broker error listeners

### DIFF
--- a/index.js
+++ b/index.js
@@ -439,11 +439,13 @@ function Execution(engine, definitions, options, isRecovered = false) {
 
     function onComplete(eventName) {
       broker.publish('event', `engine.${eventName}`, {}, {type: eventName});
+      broker.off('return', onBrokerReturn);
       engine.emit(eventName, Api());
     }
 
     function onError(err) {
       broker.publish('event', 'engine.error', err, {type: 'error', mandatory: true});
+      broker.off('return', onBrokerReturn);
     }
 
     function emitListenerEvent(...args) {


### PR DESCRIPTION
## Summary
- stop accumulating `broker.return` listeners by removing them when the
  engine completes, stops, or errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68401f0b722c83289ba97f2568607cf7